### PR TITLE
Create backup script instead of manual adb pull of every partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,23 +76,7 @@ Now, running `adb shell` again should present you with a password-less rootshell
 ### 4. Backups!
 
 With a working ADB connection, now is the time to pull a backup of everything.<br/>
-For that, simply run the following commands:
-
-```
-adb pull /proc/partitions
-
-adb pull /dev/nanda
-adb pull /dev/nandb
-adb pull /dev/nandc
-adb pull /dev/nandd
-adb pull /dev/nande
-adb pull /dev/nandf
-adb pull /dev/nandg
-adb pull /dev/nandh
-adb pull /dev/nandi
-```
-
-If the partitions file contains even more nand partitions then also backup those!
+For that, run `create-backup.sh` on the host machine. It'll backup every partition listed in `/proc/partitions` into `backup/` folder and `backup.tar.gz` archive.
 
 ### 5. Install Valetudo
 

--- a/create-backup.sh
+++ b/create-backup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+backup_folder="backup"
+
+mkdir -p $backup_folder
+pushd $backup_folder
+
+adb pull /proc/partitions
+
+partitions=$(awk -F ' ' 'NR>2 {print $4}' partitions)
+partition_count=$(< partitions wc -l)
+
+echo "Pulling ${partition_count} partition/s:"
+for partition in $partitions; do
+	partition_path="/dev/${partition}"
+	echo "Pulling partition: $partition_path"
+	adb pull "$partition_path"
+done
+
+popd
+
+tarfile="${backup_folder}.tar.gz"
+
+echo "Archiving backup/ folder into ${tarfile}"
+tar -czvf $tarfile $backup_folder


### PR DESCRIPTION
Implement `create-backup.sh` script that:
1. creates `backup/` folder and pulls `/proc/partitions`
2. backups every partition that's listed in column `name`
3. archives `backup/` folder into `backup.tar.gz`

This script eliminates the need to manually check `partitions` file to see whether there are additional partitions to backup other then ones that were listed in `README.md`.