### PR TITLE
Added adb_shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,7 @@ $ adb shell
 TinaLinux login:
 ```
 
-then simply create a file named `adb_shell` with these contents:
-
-```
-#!/bin/sh
-export ENV='/etc/adb_profile'
-exec /bin/sh "$@"
-```
-
-`chmod +x` that file and then `adb push ./adb_shell /bin/adb_shell`.
+then run `adb push ./adb_shell /bin/adb_shell`.
 
 Now, running `adb shell` again should present you with a password-less rootshell.
 

--- a/adb_shell
+++ b/adb_shell
@@ -1,0 +1,3 @@
+#!/bin/sh
+export ENV='/etc/adb_profile'
+exec /bin/sh "$@"


### PR DESCRIPTION
I added the `adb_shell` file and updated the README.md

Providing the `adb_shell` file, so that users simply have to push it, make it, in my opinion, easier for users with less Linux experience to install Valetudeo on 3irobotix CRL-200S-based vacuum robots