### PR TITLE
note about disabling existing cleaning schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Additionally, be advised that rooting these **can** work for some but **cause br
 In general, rooting vacuum robots is a dangerous procedure that can lead to unfixable bricks.
 Make sure to not attempt to root anything that you can't afford to lose.
 
+**Preparing the robot**:<br/>
+In case you currently have cleaning schedules set up on the robot, please make sure to disable or delete them before rooting.
+Otherwise, those will stay active and you won't be able to disable them later via the app.
+(Disabling them later is still possible via SSH though by manually editing the file `/mnt/UDISK/config/booking_list_config.ini` and setting `order_enable=0` for each task.)
+
 ## Prerequisites
 
 * a linux machine with a working `adb` install


### PR DESCRIPTION
After having rooted my Proscenic M6 Pro I found myself in a situation where the robot still executed cleaning schedules that I had set up previously via the OEM app.

Not only was it executing the schedules but also doing so at 3:30 at night instead of 9:30 in the morning. The only way I was able to disable the scheduled cleaning tasks by manually editing a config file via SSH.

To prevent other users from running into the same issue I've added a paragraph to the instructions.